### PR TITLE
Implement blog page customization via the opening panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,9 @@
 		"react-dom": "^18.2.0"
 	},
 	"lint-staged": {
-		"*.{css,scss}": "yarn stylelint:fix",
-		"*.{js,jsx,ts,tsx}": "yarn lint",
-		"*.{js,jsx,ts,tsx,json,css,scss,md}": "yarn format"
+		"*.{css,scss}": "npm run stylelint:fix",
+		"*.{js,jsx,ts,tsx}": "npm run lint",
+		"*.{js,jsx,ts,tsx,json,css,scss,md}": "npm run format"
 	},
 	"config": {
 		"commitizen": {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,0 +1,30 @@
+import { CSSProperties, useState } from 'react';
+import styles from '../../styles/index.module.scss';
+import {
+	ArticleStateType,
+	defaultArticleState,
+} from '../../constants/articleProps';
+import { ArticleParamsForm } from '../article-params-form';
+import { Article } from '../article';
+
+export const App = () => {
+	const [articleState, setArticleState] =
+		useState<ArticleStateType>(defaultArticleState);
+
+	return (
+		<div
+			className={styles.main}
+			style={
+				{
+					'--font-family': articleState.fontFamilyOption.value,
+					'--font-size': articleState.fontSizeOption.value,
+					'--font-color': articleState.fontColorOption.value,
+					'--container-width': articleState.contentWidthArrOption.value,
+					'--bg-color': articleState.backgroundColorOption.value,
+				} as CSSProperties
+			}>
+			<ArticleParamsForm changeStyles={setArticleState} />
+			<Article />
+		</div>
+	);
+};

--- a/src/components/arrow-button/ArrowButton.module.scss
+++ b/src/components/arrow-button/ArrowButton.module.scss
@@ -9,8 +9,17 @@
 	width: 100px;
 	height: 100px;
 	background-color: #000000;
-	border-right: 1px;
+	border: 1px;
 	transition: transform 0.5s ease;
+	transition: background 0.3s ease;
+}
+
+.container:hover {
+	background-color: var(--gold, #ffc802);
+}
+
+.container:active {
+	background-color: #787878;
 }
 
 .container_open {

--- a/src/components/arrow-button/ArrowButton.module.scss
+++ b/src/components/arrow-button/ArrowButton.module.scss
@@ -10,8 +10,7 @@
 	height: 100px;
 	background-color: #000000;
 	border: 1px;
-	transition: transform 0.5s ease;
-	transition: background 0.3s ease;
+	transition: background 0.3s ease, transform 0.5s ease;
 }
 
 .container:hover {

--- a/src/components/arrow-button/ArrowButton.stories.tsx
+++ b/src/components/arrow-button/ArrowButton.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
 import { ArrowButton } from './ArrowButton';
 
 const meta: Meta<typeof ArrowButton> = {
@@ -13,7 +12,12 @@ export const ArrowButtonStory: Story = {
 	render: () => {
 		return (
 			<>
-				<ArrowButton />
+				<ArrowButton
+					isOpen
+					onClick={() => {
+						console.log('');
+					}}
+				/>
 			</>
 		);
 	},

--- a/src/components/arrow-button/ArrowButton.tsx
+++ b/src/components/arrow-button/ArrowButton.tsx
@@ -14,12 +14,12 @@ export const ArrowButton: FC<ArrowProps> = ({ isOpen, onClick }) => {
 			role='button'
 			aria-label='Открыть/Закрыть форму параметров статьи'
 			tabIndex={0}
-			className={clsx(styles.container, isOpen && styles.container_open)}
+			className={clsx(styles.container, { [styles.container_open]: isOpen })}
 			onClick={onClick}>
 			<img
 				src={arrowSvg}
 				alt='иконка стрелочки'
-				className={clsx(styles.arrow, isOpen && styles.arrow_open)}
+				className={clsx(styles.arrow, { [styles.arrow_open]: isOpen })}
 			/>
 		</button>
 	);

--- a/src/components/arrow-button/ArrowButton.tsx
+++ b/src/components/arrow-button/ArrowButton.tsx
@@ -1,19 +1,26 @@
-import arrow from 'src/images/arrow.svg';
-
+import arrowSvg from 'src/images/arrow.svg';
 import styles from './ArrowButton.module.scss';
+import { FC } from 'react';
+import clsx from 'clsx';
 
-/** Функция для обработки открытия/закрытия формы */
-export type OnClick = () => void;
+type ArrowProps = {
+	onClick: () => void;
+	isOpen: boolean;
+};
 
-export const ArrowButton = () => {
+export const ArrowButton: FC<ArrowProps> = ({ isOpen, onClick }) => {
 	return (
-		/* Не забываем указаывать role и aria-label атрибуты для интерактивных элементов */
-		<div
+		<button
 			role='button'
 			aria-label='Открыть/Закрыть форму параметров статьи'
 			tabIndex={0}
-			className={styles.container}>
-			<img src={arrow} alt='иконка стрелочки' className={styles.arrow} />
-		</div>
+			className={clsx(styles.container, isOpen && styles.container_open)}
+			onClick={onClick}>
+			<img
+				src={arrowSvg}
+				alt='иконка стрелочки'
+				className={clsx(styles.arrow, isOpen && styles.arrow_open)}
+			/>
+		</button>
 	);
 };

--- a/src/components/article-params-form/ArticleParamsForm.module.scss
+++ b/src/components/article-params-form/ArticleParamsForm.module.scss
@@ -16,6 +16,7 @@
 	display: flex;
 	flex-shrink: 0;
 	flex-direction: column;
+	gap: 50px;
 	box-sizing: border-box;
 	width: 616px;
 	height: auto;

--- a/src/components/article-params-form/ArticleParamsForm.tsx
+++ b/src/components/article-params-form/ArticleParamsForm.tsx
@@ -27,11 +27,11 @@ type FormProps = Dispatch<SetStateAction<ArticleStateType>>;
 export const ArticleParamsForm: FC<{ changeStyles: FormProps }> = ({
 	changeStyles,
 }) => {
-	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const [isMenuOpen, seIsMenuOpen] = useState<boolean>(false);
 	const [options, setOptions] = useState<ArticleStateType>(defaultArticleState);
 
 	const onArrowButtonClick = () => {
-		setIsOpen((state: typeof isOpen) => !state);
+		seIsMenuOpen((state: typeof isMenuOpen) => !state);
 	};
 
 	const changeOption = (
@@ -63,14 +63,14 @@ export const ArticleParamsForm: FC<{ changeStyles: FormProps }> = ({
 
 	const asideRef = useRef<HTMLDivElement>(null);
 	const handleClose = () => {
-		setIsOpen(false);
+		seIsMenuOpen(false);
 	};
 
 	useClose({
-		isOpen,
+		isOpen: isMenuOpen,
 		rootRef: asideRef,
 		onClose: handleClose,
-		onChange: setIsOpen,
+		onChange: seIsMenuOpen,
 	});
 
 	const resetOptions = () => {
@@ -85,10 +85,12 @@ export const ArticleParamsForm: FC<{ changeStyles: FormProps }> = ({
 
 	return (
 		<>
-			<ArrowButton isOpen={isOpen} onClick={onArrowButtonClick} />
+			<ArrowButton isOpen={isMenuOpen} onClick={onArrowButtonClick} />
 			<aside
 				ref={asideRef}
-				className={clsx(styles.container, isOpen && styles.container_open)}>
+				className={clsx(styles.container, {
+					[styles.container_open]: isMenuOpen,
+				})}>
 				<form
 					className={styles.form}
 					onReset={resetOptions}

--- a/src/components/article-params-form/ArticleParamsForm.tsx
+++ b/src/components/article-params-form/ArticleParamsForm.tsx
@@ -1,14 +1,133 @@
-import { ArrowButton } from 'components/arrow-button';
-import { Button } from 'components/button';
-
+import { Dispatch, FC, SetStateAction, useRef, useState } from 'react';
+import clsx from 'clsx';
 import styles from './ArticleParamsForm.module.scss';
 
-export const ArticleParamsForm = () => {
+import {
+	ArticleStateType,
+	backgroundColorOptions,
+	contentWidthArrOptions,
+	defaultArticleState,
+	fontColorOptions,
+	fontFamilyOptions,
+	fontSizeOptions,
+	OptionType,
+} from '../../constants/articleProps';
+
+import { useClose } from './hooks/useClose';
+
+import { ArrowButton } from 'components/arrow-button';
+import { Button } from '../button';
+import { Text } from '../text';
+import { Select } from '../select';
+import { RadioGroup } from '../radio-group';
+import { Separator } from '../separator';
+
+type FormProps = Dispatch<SetStateAction<ArticleStateType>>;
+
+export const ArticleParamsForm: FC<{ changeStyles: FormProps }> = ({
+	changeStyles,
+}) => {
+	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const [options, setOptions] = useState<ArticleStateType>(defaultArticleState);
+
+	const onArrowButtonClick = () => {
+		setIsOpen((state: typeof isOpen) => !state);
+	};
+
+	const changeOption = (
+		optionKey: keyof ArticleStateType,
+		optionType: OptionType
+	) => {
+		setOptions({ ...options, [optionKey]: optionType });
+	};
+
+	const onFontFamilyChange = (selectedOption: OptionType) => {
+		changeOption('fontFamilyOption', selectedOption);
+	};
+
+	const onFontSizeChange = (selectedOption: OptionType) => {
+		changeOption('fontSizeOption', selectedOption);
+	};
+
+	const onFontColorChange = (selectedOption: OptionType) => {
+		changeOption('fontColorOption', selectedOption);
+	};
+
+	const onBackgroundColorChange = (selectedOption: OptionType) => {
+		changeOption('backgroundColorOption', selectedOption);
+	};
+
+	const onContentWidthArrChange = (selectedOption: OptionType) => {
+		changeOption('contentWidthArrOption', selectedOption);
+	};
+
+	const asideRef = useRef<HTMLDivElement>(null);
+	const handleClose = () => {
+		setIsOpen(false);
+	};
+
+	useClose({
+		isOpen,
+		rootRef: asideRef,
+		onClose: handleClose,
+		onChange: setIsOpen,
+	});
+
+	const resetOptions = () => {
+		setOptions(defaultArticleState);
+		changeStyles(defaultArticleState);
+	};
+
+	const applyOptions = (evt: React.FormEvent<HTMLFormElement>) => {
+		evt.preventDefault();
+		changeStyles(options);
+	};
+
 	return (
 		<>
-			<ArrowButton />
-			<aside className={styles.container}>
-				<form className={styles.form}>
+			<ArrowButton isOpen={isOpen} onClick={onArrowButtonClick} />
+			<aside
+				ref={asideRef}
+				className={clsx(styles.container, isOpen && styles.container_open)}>
+				<form
+					className={styles.form}
+					onReset={resetOptions}
+					onSubmit={applyOptions}>
+					<Text as={'h2'} size={31} weight={800} uppercase={true}>
+						Задайте параметры
+					</Text>
+					<Select
+						title='Шрифт'
+						selected={options.fontFamilyOption}
+						options={fontFamilyOptions}
+						onChange={onFontFamilyChange}
+					/>
+					<RadioGroup
+						title='Размер шрифта'
+						name={''}
+						selected={options.fontSizeOption}
+						options={fontSizeOptions}
+						onChange={onFontSizeChange}
+					/>
+					<Select
+						title='Цвет шрифта'
+						selected={options.fontColorOption}
+						options={fontColorOptions}
+						onChange={onFontColorChange}
+					/>
+					<Separator />
+					<Select
+						title='Цвет фона'
+						selected={options.backgroundColorOption}
+						options={backgroundColorOptions}
+						onChange={onBackgroundColorChange}
+					/>
+					<Select
+						title='Ширина контента'
+						selected={options.contentWidthArrOption}
+						options={contentWidthArrOptions}
+						onChange={onContentWidthArrChange}
+					/>
 					<div className={styles.bottomContainer}>
 						<Button title='Сбросить' type='reset' />
 						<Button title='Применить' type='submit' />

--- a/src/components/article-params-form/hooks/useClose.tsx
+++ b/src/components/article-params-form/hooks/useClose.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+type UseClose = {
+	isOpen: boolean;
+	onChange: (newValue: boolean) => void;
+	onClose?: () => void;
+	rootRef: React.RefObject<HTMLDivElement>;
+};
+
+export const useClose = ({ isOpen, rootRef, onClose, onChange }: UseClose) => {
+	useEffect(() => {
+		const handleOutsideClickClose = (evt: MouseEvent) => {
+			const { target } = evt;
+			if (target instanceof Node && !rootRef.current?.contains(target)) {
+				isOpen && onClose?.();
+				onChange?.(false);
+			}
+		};
+
+		const handleCloseByEsc = (evt: KeyboardEvent) => {
+			if (evt.key === 'Escape') {
+				onChange?.(false);
+			}
+		};
+
+		document.addEventListener('mousedown', handleOutsideClickClose);
+		document.addEventListener('keydown', handleCloseByEsc);
+
+		return () => {
+			document.removeEventListener('mousedown', handleOutsideClickClose);
+			document.removeEventListener('keydown', handleCloseByEsc);
+		};
+	}, [onClose, onChange, isOpen]);
+};

--- a/src/components/article-params-form/hooks/useClose.tsx
+++ b/src/components/article-params-form/hooks/useClose.tsx
@@ -9,6 +9,7 @@ type UseClose = {
 
 export const useClose = ({ isOpen, rootRef, onClose, onChange }: UseClose) => {
 	useEffect(() => {
+		if (!isOpen) return;
 		const handleOutsideClickClose = (evt: MouseEvent) => {
 			const { target } = evt;
 			if (target instanceof Node && !rootRef.current?.contains(target)) {
@@ -25,10 +26,5 @@ export const useClose = ({ isOpen, rootRef, onClose, onChange }: UseClose) => {
 
 		document.addEventListener('mousedown', handleOutsideClickClose);
 		document.addEventListener('keydown', handleCloseByEsc);
-
-		return () => {
-			document.removeEventListener('mousedown', handleOutsideClickClose);
-			document.removeEventListener('keydown', handleCloseByEsc);
-		};
-	}, []);
+	}, [isOpen]);
 };

--- a/src/components/article-params-form/hooks/useClose.tsx
+++ b/src/components/article-params-form/hooks/useClose.tsx
@@ -30,5 +30,5 @@ export const useClose = ({ isOpen, rootRef, onClose, onChange }: UseClose) => {
 			document.removeEventListener('mousedown', handleOutsideClickClose);
 			document.removeEventListener('keydown', handleCloseByEsc);
 		};
-	}, [onClose, onChange, isOpen]);
+	}, []);
 };

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -6,14 +6,24 @@
 	width: 210px;
 	height: 50px;
 	text-align: center;
+	background-color: #ffffff;
 	border: 1px solid #000000;
 	cursor: pointer;
+	transition: background 0.3s ease;
 }
 
-.button:active {
+.button[type='submit'] {
 	background: var(--gold, #ffc802);
+}
+
+.button[type='reset']:hover > * {
+	color: #ffffff;
+}
+
+.button[type='submit']:hover {
+	background: #ffedab;
 }
 
 .button:hover {
-	background: var(--gold, #ffc802);
+	background: #000000;
 }

--- a/src/components/radio-group/RadioGroup.module.scss
+++ b/src/components/radio-group/RadioGroup.module.scss
@@ -30,9 +30,8 @@
 	text-align: center;
 	border-right: 1px solid #000000;
 	cursor: pointer;
+	transition: background 0.3s ease;
 }
-
-/* Убираем бордер у последнего в radiogroup, чтобы не было двойного бордера */
 
 .item:last-child .label {
 	border: none;
@@ -40,7 +39,7 @@
 
 .label:hover,
 .item[data-checked='true'] .label:hover {
-	background: var(--gold, #ffc802);
+	background: #ffedab;
 }
 
 .item[data-checked='true'] .label {

--- a/src/components/select/Select.module.scss
+++ b/src/components/select/Select.module.scss
@@ -27,6 +27,7 @@
 	background: rgb(255 255 255);
 	outline: 1px solid #000000;
 	cursor: pointer;
+	transition: outline 0.3s ease;
 }
 
 .placeholder[data-selected='true'] {
@@ -44,7 +45,7 @@
 
 .selectWrapper:not([data-is-active='true'])
 	.placeholder:not([data-status='invalid']):hover {
-	outline: 3px solid #000000;
+	outline: 1px solid var(--gold, #ffc802);
 }
 
 .select {
@@ -78,7 +79,11 @@
 }
 
 .option:hover {
-	background: var(--grey, #c4c4c4);
+	background: #eeeeee;
+}
+
+.option:active {
+	background: #d7d7d7;
 }
 
 @mixin option-color-before {

--- a/src/components/separator/index.module.scss
+++ b/src/components/separator/index.module.scss
@@ -1,5 +1,5 @@
 .separator {
 	width: 100%;
 	height: 1px;
-	background: #000000;
+	background: #d7d7d7;
 }

--- a/src/constants/articleProps.ts
+++ b/src/constants/articleProps.ts
@@ -33,7 +33,7 @@ export const fontFamilyOptions: OptionType[] & {
 	},
 ];
 
-export const fontColors: OptionType[] = [
+export const fontColorOptions: OptionType[] = [
 	{
 		title: 'Черный',
 		value: '#000000',
@@ -90,7 +90,7 @@ export const fontColors: OptionType[] = [
 	},
 ];
 
-export const backgroundColors: OptionType[] = [
+export const backgroundColorOptions: OptionType[] = [
 	{
 		title: 'Белый',
 		value: '#FFFFFF',
@@ -147,7 +147,7 @@ export const backgroundColors: OptionType[] = [
 	},
 ];
 
-export const contentWidthArr: OptionType[] = [
+export const contentWidthArrOptions: OptionType[] = [
 	{
 		title: 'Широкий',
 		value: '1394px',
@@ -170,9 +170,9 @@ export const fontSizeOptions: OptionType[] = [
 
 export const defaultArticleState = {
 	fontFamilyOption: fontFamilyOptions[0],
-	fontColor: fontColors[0],
-	backgroundColor: backgroundColors[0],
-	contentWidth: contentWidthArr[0],
+	fontColorOption: fontColorOptions[0],
+	backgroundColorOption: backgroundColorOptions[0],
+	contentWidthArrOption: contentWidthArrOptions[0],
 	fontSizeOption: fontSizeOptions[0],
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,44 +1,17 @@
 import { createRoot } from 'react-dom/client';
-import { StrictMode, CSSProperties, useState } from 'react';
-import clsx from 'clsx';
-
-import { Article } from './components/article/Article';
-import {
-	ArticleStateType,
-	defaultArticleState,
-} from './constants/articleProps';
+import { StrictMode } from 'react';
 
 import './styles/index.scss';
-import styles from './styles/index.module.scss';
-import { ArticleParamsForm } from './components/article-params-form';
+import { App } from './components/App/App';
 
 const domNode = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(domNode);
 
-const App = () => {
-	const [articleState, setArticleState] =
-		useState<ArticleStateType>(defaultArticleState);
-
-	return (
-		<div
-			className={clsx(styles.main)}
-			style={
-				{
-					'--font-family': articleState.fontFamilyOption.value,
-					'--font-size': articleState.fontSizeOption.value,
-					'--font-color': articleState.fontColorOption.value,
-					'--container-width': articleState.contentWidthArrOption.value,
-					'--bg-color': articleState.backgroundColorOption.value,
-				} as CSSProperties
-			}>
-			<ArticleParamsForm changeStyles={setArticleState} />
-			<Article />
-		</div>
-	);
-};
-
 root.render(
 	<StrictMode>
-		<App />
+		<header></header>
+		<main>
+			<App />
+		</main>
 	</StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,31 +1,37 @@
 import { createRoot } from 'react-dom/client';
-import { StrictMode, CSSProperties } from 'react';
+import { StrictMode, CSSProperties, useState } from 'react';
 import clsx from 'clsx';
 
 import { Article } from './components/article/Article';
-import { ArticleParamsForm } from './components/article-params-form/ArticleParamsForm';
-import { defaultArticleState } from './constants/articleProps';
+import {
+	ArticleStateType,
+	defaultArticleState,
+} from './constants/articleProps';
 
 import './styles/index.scss';
 import styles from './styles/index.module.scss';
+import { ArticleParamsForm } from './components/article-params-form';
 
 const domNode = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(domNode);
 
 const App = () => {
+	const [articleState, setArticleState] =
+		useState<ArticleStateType>(defaultArticleState);
+
 	return (
 		<div
 			className={clsx(styles.main)}
 			style={
 				{
-					'--font-family': defaultArticleState.fontFamilyOption.value,
-					'--font-size': defaultArticleState.fontSizeOption.value,
-					'--font-color': defaultArticleState.fontColor.value,
-					'--container-width': defaultArticleState.contentWidth.value,
-					'--bg-color': defaultArticleState.backgroundColor.value,
+					'--font-family': articleState.fontFamilyOption.value,
+					'--font-size': articleState.fontSizeOption.value,
+					'--font-color': articleState.fontColorOption.value,
+					'--container-width': articleState.contentWidthArrOption.value,
+					'--bg-color': articleState.backgroundColorOption.value,
 				} as CSSProperties
 			}>
-			<ArticleParamsForm />
+			<ArticleParamsForm changeStyles={setArticleState} />
 			<Article />
 		</div>
 	);


### PR DESCRIPTION
**Задачи:**
- [x] Собрать компонент формы согласно макету.
- [x] Реализовать механику открытия-закрытия панели.
- [x] Реализовать сохранение состояния страницы и состояние формы.

**Функционал:**

- При нажатии на «стрелку» открывается сайдбар с настройками, при повторном нажатии или клике вне сайдбар закрывается.
-  При изменении настроек в сайдбаре они не применяются сразу.
- После нажатия на «применить» стили применяются к статье.
- При нажатии «сбросить» настройки в форме сбрасываются на начальные, которые были при открытии страницы, и стили применяются к статье.
- Настройки устанавливаются через CSS-переменные, которые уже есть в стилях и установлены в коде в дефолтные значения.